### PR TITLE
Some improvements and refactoring

### DIFF
--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -7,5 +7,5 @@
   }
 
   window.asset_path       = function(){ assets.asset_path.apply(assets, arguments) }
-  window.asset_path.files = files
+  window.asset_path.files = assets.files
 })();

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -2,11 +2,11 @@
   var assets = {
     files       : <%= JsAssets::List.to_json %>,
     asset_path  : function(path){
-      console.log("Resolving file: " + path)
+      console.log("Resolving file: " + path + "from %O", this.files)
       return this.files[path];
     }
   }
 
   window.asset_path       = function(){ assets.asset_path.apply(assets, arguments) }
-  window.asset_path.files = assets.files
+  // window.asset_path.files = assets.files
 })();

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -1,12 +1,9 @@
 (function(){
   var assets = {
     files       : <%= JsAssets::List.to_json %>,
-    asset_path  : function(path){
-      console.log("Resolving file: " + path + "from %O", this.files)
-      return this.files[path];
-    }
+    asset_path  : function(path){ return this.files[path]; }
   }
 
-  window.asset_path       = function(){ assets.asset_path.apply(assets, arguments) }
-  // window.asset_path.files = assets.files
+  window.asset_path       = function(){ return assets.asset_path.apply(assets, arguments) }
+  window.asset_path.files = assets.files
 })();

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -1,11 +1,11 @@
 (function(){
-  assets = {
+  var assets = {
     files       : <%= JsAssets::List.to_json %>,
     asset_path  : function(path){
       return this.files[path];
     }
   }
 
-  window.asset_path       = assets.asset_path
-  window.asset_path.files = assets.files
+  window.asset_path       = function(){ assets.asset_path.apply(assets, arguments) }
+  window.asset_path.files = files
 })();

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -1,4 +1,5 @@
-window.project_assets = <%= JsAssets::List.fetch.to_json %>;
-window.asset_path = function(logical_path) {
-  return window.project_assets[logical_path];
-};
+window.asset_path = function(logical_path){
+  return this.files[logical_path];
+}
+
+asset_path.files = <%= JsAssets::List.to_json %>;

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -2,6 +2,7 @@
   var assets = {
     files       : <%= JsAssets::List.to_json %>,
     asset_path  : function(path){
+      console.log("Resolving file: " + path)
       return this.files[path];
     }
   }

--- a/app/assets/javascripts/app_assets.js.erb
+++ b/app/assets/javascripts/app_assets.js.erb
@@ -1,5 +1,11 @@
-window.asset_path = function(logical_path){
-  return this.files[logical_path];
-}
+(function(){
+  assets = {
+    files       : <%= JsAssets::List.to_json %>,
+    asset_path  : function(path){
+      return this.files[path];
+    }
+  }
 
-asset_path.files = <%= JsAssets::List.to_json %>;
+  window.asset_path       = assets.asset_path
+  window.asset_path.files = assets.files
+})();

--- a/js_assets.gemspec
+++ b/js_assets.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '~> 0'
+  s.add_dependency "rails"
 
-  s.add_development_dependency 'yard', '~> 0'
+  s.add_development_dependency "yard"
 end

--- a/js_assets.gemspec
+++ b/js_assets.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails"
+  s.add_dependency 'rails', '~> 0'
 
-  s.add_development_dependency "yard"
+  s.add_development_dependency 'yard', '~> 0'
 end

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -21,7 +21,6 @@ module JsAssets
       end
     end
 
-
   protected
 
     def self.file_allowed?(path, name)

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -1,7 +1,7 @@
 module JsAssets
   class List
     class << self
-      attr_accessor :exclude, :allow
+      attr_accessor :exclude, :allow, :use_file_filter
     end
     @exclude          = ['application.js']
     @allow            = ['*.html']

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -25,13 +25,16 @@ module JsAssets
   protected
 
     def self.file_allowed?(path, name)
-      return false if matches_filter(@exclude, path, name)
-      return false if !matches_filter(@allow, path, name)
-      return true
+      !matches_filter(@exclude, path, name) && matches_filter(@allow, path, name)
     end
 
     def self.asset_path(path)
-      ActionController::Base.helpers.asset_path(path)
+      if digest?
+        file_path = ::Rails.application.assets[path].digest_path
+      else
+        file_path = path
+      end
+      return File.join('/', config.assets.prefix, file_path)
     end
 
     # will return logical path for the asset
@@ -47,7 +50,11 @@ module JsAssets
     def self.assets
       ::Rails.application.assets
     end
-
+    
+    def self.digest?
+      config.assets.digest
+    end
+    
     # from 
     # https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/base.rb:418
     def self.matches_filter(filters, logical_path, filename)

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -11,9 +11,7 @@ module JsAssets
     end
 
     def self.fetch
-      assets  = {}
-      files   = ::Rails.application.assets
-      assets  = files.each_file.reduce({}) do |res, filename|
+      return assets.each_file.reduce({}) do |res, filename|
         if (logical_path = get_logical_path(filename))
           if file_allowed?(logical_path, filename)
             res[logical_path] = asset_path(logical_path)
@@ -21,15 +19,14 @@ module JsAssets
         end
         res
       end
-      return assets
     end
 
 
   protected
 
     def file_allowed?(path, name)
-      return false if matches_filter(@exclude, logical_path, filename)
-      return false if !matches_filter(@allow, logical_path, filename)
+      return false if matches_filter(@exclude, path, name)
+      return false if !matches_filter(@allow, path, name)
       return true
     end
 
@@ -39,8 +36,15 @@ module JsAssets
 
     # will return logical path for the asset
     def get_logical_path(file)
-      filter = ::Rails.application.config.assets.precompile
-      ::Rails.application.assets.send(:logical_path_for_filename, file, filter)
+      assets.send(:logical_path_for_filename, file, [])
+    end
+
+    def config
+      ::Rails.application.config
+    end
+
+    def assets
+      ::Rails.application.assets
     end
 
     # from 

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -3,8 +3,9 @@ module JsAssets
     class << self
       attr_accessor :exclude, :allow
     end
-    @exclude  = ['application.js']
-    @allow    = ['*.html']
+    @exclude          = ['application.js']
+    @allow            = ['*.html']
+    @use_file_filter  = true
 
     def self.to_json
       fetch.to_json
@@ -35,7 +36,8 @@ module JsAssets
 
     # will return logical path for the asset
     def self.get_logical_path(file)
-      assets.send(:logical_path_for_filename, file, [])
+      filter = @use_file_filter ? config.assets.precompile : []
+      assets.send(:logical_path_for_filename, file, filter)
     end
 
     def self.config

--- a/lib/js_assets/list.rb
+++ b/lib/js_assets/list.rb
@@ -24,26 +24,26 @@ module JsAssets
 
   protected
 
-    def file_allowed?(path, name)
+    def self.file_allowed?(path, name)
       return false if matches_filter(@exclude, path, name)
       return false if !matches_filter(@allow, path, name)
       return true
     end
 
-    def asset_path(path)
+    def self.asset_path(path)
       ActionController::Base.helpers.asset_path(path)
     end
 
     # will return logical path for the asset
-    def get_logical_path(file)
+    def self.get_logical_path(file)
       assets.send(:logical_path_for_filename, file, [])
     end
 
-    def config
+    def self.config
       ::Rails.application.config
     end
 
-    def assets
+    def self.assets
       ::Rails.application.assets
     end
 

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.0.9"
+  VERSION = "0.1.2"
 end

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/lib/js_assets/version.rb
+++ b/lib/js_assets/version.rb
@@ -1,3 +1,3 @@
 module JsAssets
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
I've added few improvements such as `ActionController::Base.helpers.asset_path` instead of self-writen resolver. It works using your environments so there is no more reasons to handle it with `config.assets.digest` or anything else.

I've also added option `use_file_filter` to handle how to resolve paths. For example in my projects i have `config.assets.precompile` configured only in production so these path won't be resolved in development. By default this options is set to `true`.

``` ruby
JsAssets::List.use_file_filter = false
```

Also i've fixed `app_assets.js`. Now list of files is hidden under local object and all code sits under self-invoking function. This fix was made to cleanup global object. But if you need to access files list directly you can call `files` on `asset_path` function:

``` javascript
var files = asset_path.files
```

And i've made total refactoring of `JsAssets::List` to make it more readable and simple.
